### PR TITLE
chore(deps): move @babel/types to dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,13 +16,13 @@
         "@babel/generator": "^7.11.6",
         "@babel/parser": "^7.11.5",
         "@babel/traverse": "^7.11.5",
+        "@babel/types": "7.17.0",
         "hotkeys-js": "^3.8.1",
         "loader-utils": "^2.0.0",
         "querystring": "^0.2.1",
         "react-dev-utils": "^12.0.1"
       },
       "devDependencies": {
-        "@babel/types": "7.17.0",
         "@commitlint/cli": "16.2.3",
         "@commitlint/config-conventional": "16.2.1",
         "@types/babel__traverse": "7.17.0",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "react-dev-inspector",
+  "name": "customized-react-dev-inspector",
   "version": "1.8.0",
   "sideEffects": false,
   "description": "dev-tool for inspect react components and jump to local IDE for component code.",
@@ -19,7 +19,7 @@
     "tag": "git tag v$(node -e 'console.log(require(\"./package.json\").version)')",
     "lint": "TIMING=1 eslint --quiet --ext js,jsx,ts,tsx src examples"
   },
-  "repository": "zthxxx/react-dev-inspector",
+  "repository": "heiseshandian/react-dev-inspector",
   "publishConfig": {
     "registry": "https://registry.npmjs.org"
   },
@@ -28,12 +28,12 @@
     "component",
     "inspector"
   ],
-  "author": "zthxxx",
+  "author": "baymax",
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/zthxxx/react-dev-inspector/issues"
+    "url": "https://github.com/heiseshandian/react-dev-inspector/issues"
   },
-  "homepage": "https://github.com/zthxxx/react-dev-inspector#readme",
+  "homepage": "https://github.com/heiseshandian/react-dev-inspector#readme",
   "files": [
     "README.md",
     ".npmrc",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "customized-react-dev-inspector",
-  "version": "1.8.0",
+  "version": "1.8.1",
   "sideEffects": false,
   "description": "dev-tool for inspect react components and jump to local IDE for component code.",
   "workspaces": [

--- a/package.json
+++ b/package.json
@@ -54,10 +54,10 @@
     "hotkeys-js": "^3.8.1",
     "loader-utils": "^2.0.0",
     "querystring": "^0.2.1",
-    "react-dev-utils": "^12.0.1"
+    "react-dev-utils": "^12.0.1",
+    "@babel/types": "7.17.0"
   },
   "devDependencies": {
-    "@babel/types": "7.17.0",
     "@commitlint/cli": "16.2.3",
     "@commitlint/config-conventional": "16.2.1",
     "@types/babel__traverse": "7.17.0",

--- a/src/plugins/webpack/inspector-plugin.ts
+++ b/src/plugins/webpack/inspector-plugin.ts
@@ -27,14 +27,5 @@ export class ReactInspectorPlugin {
       result.unshift(launchEditorMiddleware)
       return result
     }
-
-    /**
-     * for webpack@^4 + webpack-dev-server@^3
-     */
-    const originBefore = devServer.before
-    devServer.before = (app, server, compiler) => {
-      app.use(launchEditorMiddleware)
-      originBefore?.(app, server, compiler)
-    }
   }
 }


### PR DESCRIPTION
Currently, in `src/plugins/babel/visitor.ts`, we directly use the utils imported from `@babel/types/lib/builders/generated`, which means `@babel/types/lib/builders/generated` is not only needed during development, we should put it under `dependencies` instead of `devDependencies`.

```ts
import {
  jsxAttribute,
  jsxIdentifier,
  stringLiteral,
} from '@babel/types/lib/builders/generated'
//...

const lineAttr: JSXAttribute | null = isNil(line)
    ? null
    : jsxAttribute(
      jsxIdentifier('data-inspector-line'),
      stringLiteral(line.toString()),
    )
```