### PR TITLE
fix docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ screen record gif (8M size):
 ## Installation
 
 ```bash
-npm i -D react-dev-inspector
+npm i react-dev-inspector
 ```
 
 ## Usage
@@ -71,7 +71,7 @@ export const Layout = () => {
             // you can change the url protocol if you are using in Web IDE
             window.open(`vscode://file/${absolutePath}:${lineNumber}:${columnNumber}`)
           }}
-        >
+        />
       )}
     </>
   )
@@ -109,7 +109,7 @@ export const Layout = () => {
           keys={['control', 'shift', 'command', 'c']}
           onHoverElement={(inspect: InspectParams) => {}}
           onClickElement={(inspect: InspectParams) => {}}
-        >
+        />
       )}
     </>
   )


### PR DESCRIPTION
1. 应将 `react-dev-inspector` 安装至 `dependencies`，因为 `process.env.NODE_ENV` 为 `production` 时不会安装 `devDependencies`，编译时 webpack 会因为无法找到依赖而报错。
2. 示例代码中的 `<Inspector />` 组件未自闭合。